### PR TITLE
Rename mapping variables in forward notebook

### DIFF
--- a/notebooks/01-forward-dc-resisitivity-2d.ipynb
+++ b/notebooks/01-forward-dc-resisitivity-2d.ipynb
@@ -644,12 +644,10 @@
    "outputs": [],
    "source": [
     "# Conductivity map. Model parameters are conductivities for all active cells.\n",
-    "resistivity_map = maps.InjectActiveCells(mesh, active_cells, air_resistivity)\n",
+    "inject_active_cells = maps.InjectActiveCells(mesh, active_cells, air_resistivity)\n",
     "\n",
     "# Resistivity map. Model parameters are log-resistivities for all active cells.\n",
-    "log_resistivity_map = maps.InjectActiveCells(\n",
-    "    mesh, active_cells, air_resistivity\n",
-    ") * maps.ExpMap(nP=n_active)"
+    "log_resistivity_map = inject_active_cells * maps.ExpMap(nP=n_active)"
    ]
   },
   {
@@ -703,7 +701,7 @@
     "\n",
     "* **mesh** (the mesh as an input argument)\n",
     "* **survey=survey** (set the survey as a keyword argument)\n",
-    "* **rhoMap=resistivity_map** (set the mapping as a keyword argument)"
+    "* **rhoMap=inject_active_cells** (set the mapping as a keyword argument)"
    ]
   },
   {
@@ -713,7 +711,7 @@
    "outputs": [],
    "source": [
     "simulation = dc.simulation_2d.Simulation2DNodal(\n",
-    "    mesh, survey=survey, rhoMap=resistivity_map\n",
+    "    mesh, survey=survey, rhoMap=inject_active_cells\n",
     ")"
    ]
   },

--- a/notebooks/01-forward-dc-resisitivity-2d.ipynb
+++ b/notebooks/01-forward-dc-resisitivity-2d.ipynb
@@ -541,16 +541,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define log-conductivity model\n",
-    "log_resistivity_model = np.log(resistivity_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
    "outputs": [
@@ -644,10 +634,7 @@
    "outputs": [],
    "source": [
     "# Conductivity map. Model parameters are conductivities for all active cells.\n",
-    "inject_active_cells = maps.InjectActiveCells(mesh, active_cells, air_resistivity)\n",
-    "\n",
-    "# Resistivity map. Model parameters are log-resistivities for all active cells.\n",
-    "log_resistivity_map = inject_active_cells * maps.ExpMap(nP=n_active)"
+    "inject_active_cells = maps.InjectActiveCells(mesh, active_cells, air_resistivity)"
    ]
   },
   {


### PR DESCRIPTION
Rename the variable for the `InjectActiveCells` map to `inject_active_cells`. Also remove the unused variables `log_resistivity_model` and `log_resistivity_map`.
