### PR TITLE
Remove unused cell in forward notebook

### DIFF
--- a/notebooks/01-forward-dc-resisitivity-2d.ipynb
+++ b/notebooks/01-forward-dc-resisitivity-2d.ipynb
@@ -73,6 +73,7 @@
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.colors import LogNorm\n",
     "\n",
+    "# Increase font size of plots\n",
     "mpl.rcParams.update({\"font.size\": 14})  # default font size\n",
     "\n",
     "write_output = False  # Optional"
@@ -430,15 +431,6 @@
    "source": [
     "# Finalize\n",
     "mesh.finalize()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mesh.plot_grid?"
    ]
   },
   {


### PR DESCRIPTION
Also add a more verbose comment while setting the font size in
matplotlib plots.
